### PR TITLE
Implement button update with packet on state change

### DIFF
--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -32,7 +32,11 @@ void Button::init()
 
 void Button::update()
 {
-
+    bool current_state = digitalRead(this->button_pin);
+    if (current_state != this->state) {
+        this->set_state(current_state);
+        this->send_packet();
+    }
 }
 
 void Button::send_packet() {

--- a/src/InputSystem.cpp
+++ b/src/InputSystem.cpp
@@ -41,7 +41,13 @@ bool InputSystem::begin() {
 }
 
 void InputSystem::update() {
-  for (auto& b : buttons) b.update();
+  buttons_update();
+}
+
+void InputSystem::buttons_update() {
+  for (auto& b : buttons) {
+    b.update();
+  }
 }
 
 void InputSystem::printConfig(const ConfigData& cfg) {

--- a/src/InputSystem.h
+++ b/src/InputSystem.h
@@ -26,7 +26,8 @@ public:
 
     InputSystem();                  // defaults to "/config.txt"
     bool begin();                   // mounts LittleFS, loads & parses file
-    void update();                  // updates all buttons
+    void update();                  // high-level update
+    void buttons_update();          // updates all buttons
     static void printConfig(const ConfigData& cfg);
 
     const std::vector<Button>& getButtons() const { return buttons; }


### PR DESCRIPTION
## Summary
- read button pin each update and send packet when state changes
- add `InputSystem::buttons_update` helper and delegate `update` to it

## Testing
- `pio run` (fails: command not found)
- `pip install platformio` (fails: tunnel connection failed 403)


------
https://chatgpt.com/codex/tasks/task_e_68a48af1d1d083239e7c18442c06a67c