### PR TITLE
Implement button update with packet on state change

### DIFF
--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -32,7 +32,11 @@ void Button::init()
 
 void Button::update()
 {
-
+    bool current_state = digitalRead(this->button_pin);
+    if (current_state != this->state) {
+        this->set_state(current_state);
+        this->send_packet();
+    }
 }
 
 void Button::send_packet() {

--- a/src/Button.h
+++ b/src/Button.h
@@ -17,7 +17,7 @@ public:
 
     void send_packet();
 private:
-    bool state;
+    bool state = HIGH;
     uint8_t button_pin;
     std::string packet_content;
 };

--- a/src/InputSystem.cpp
+++ b/src/InputSystem.cpp
@@ -34,14 +34,17 @@ bool InputSystem::begin() {
   std::istringstream iss(content);
   const auto cfg = parseConfig(iss);
   initButtonsFromConfig(cfg);
-  
-
-  for (auto& b : buttons) b.init();
   return true;
 }
 
 void InputSystem::update() {
-  for (auto& b : buttons) b.update();
+  buttons_update();
+}
+
+void InputSystem::buttons_update() {
+  for (auto& b : buttons) {
+    b.update();
+  }
 }
 
 void InputSystem::printConfig(const ConfigData& cfg) {
@@ -98,6 +101,10 @@ InputSystem::ConfigData InputSystem::parseConfig(std::istream& in) {
 
 void InputSystem::initButtonsFromConfig(const ConfigData& cfg) {
   buttons.clear();
-  for (const auto& e : cfg.buttons)     buttons.emplace_back(uint8_t(e.value), e.name);
-  for (const auto& e : cfg.dpadButtons) buttons.emplace_back(uint8_t(e.value), e.name);
+  auto add = [this](const ConfigEntry& e) {
+    buttons.emplace_back(uint8_t(e.value), e.name);
+    buttons.back().init();
+  };
+  for (const auto& e : cfg.buttons)     add(e);
+  for (const auto& e : cfg.dpadButtons) add(e);
 }

--- a/src/InputSystem.h
+++ b/src/InputSystem.h
@@ -26,7 +26,8 @@ public:
 
     InputSystem();                  // defaults to "/config.txt"
     bool begin();                   // mounts LittleFS, loads & parses file
-    void update();                  // updates all buttons
+    void update();                  // high-level update
+    void buttons_update();          // updates all buttons
     static void printConfig(const ConfigData& cfg);
 
     const std::vector<Button>& getButtons() const { return buttons; }


### PR DESCRIPTION
## Summary
- read button pin each update and send packet when state changes
- add `InputSystem::buttons_update` helper and delegate `update` to it
- initialize buttons from config immediately and default state to HIGH

## Testing
- `pio run` (fails: command not found)
- `pip install platformio` (fails: tunnel connection failed 403)


------
https://chatgpt.com/codex/tasks/task_e_68a48af1d1d083239e7c18442c06a67c