### PR TITLE
Implement LED class with state management

### DIFF
--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -2,5 +2,52 @@
 
 Led::Led(uint8_t led_pin, std::string name)
 {
-    
+    this->led_pin = led_pin;
+    this->name = name;
+}
+
+bool Led::get_state()
+{
+    return this->state;
+}
+
+void Led::set_state(bool new_state)
+{
+    this->state = new_state;
+    digitalWrite(this->led_pin, this->state);
+}
+
+uint8_t Led::get_led_pin()
+{
+    return this->led_pin;
+}
+
+void Led::init()
+{
+    pinMode(this->led_pin, OUTPUT);
+    digitalWrite(this->led_pin, this->state);
+}
+
+void Led::update()
+{
+    digitalWrite(this->led_pin, this->state);
+}
+
+void Led::toggleLed()
+{
+    this->set_state(!this->state);
+    this->send_packet();
+}
+
+void Led::send_packet()
+{
+    const char stateCh = (this->state == HIGH) ? '1' : '0';
+    constexpr uint8_t SEP = 0x1F; // ASCII Unit Separator
+
+    // Write: <name><US><0_or_1>\n
+    Serial.write(reinterpret_cast<const uint8_t*>(name.data()),
+                 name.size());
+    Serial.write(SEP);
+    Serial.write(static_cast<uint8_t>(stateCh));
+    Serial.write('\n'); // record terminator
 }

--- a/src/Led.h
+++ b/src/Led.h
@@ -6,12 +6,19 @@
 
 class Led {
 public:
-    
+    // name is identifier for this LED
     Led(uint8_t pin, std::string name);
     void init();
     void update();
 
+    uint8_t get_led_pin();
+
+    void set_state(bool new_state);
+    bool get_state();
+
     void toggleLed();
+
+    void send_packet();
 
 private:
     bool state = LOW;


### PR DESCRIPTION
## Summary
- flesh out `Led` with initialization, state helpers, and toggling
- mirror `Button` serialization so LED state changes are sent as packets

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a59b748868832384b810cceeeb958a