### PR TITLE
Add LED vector and update handling in InputSystem

### DIFF
--- a/data/config.txt
+++ b/data/config.txt
@@ -11,3 +11,4 @@ Potensiometers
 
 led
 ------
+"test" - 7

--- a/src/InputSystem.cpp
+++ b/src/InputSystem.cpp
@@ -34,19 +34,29 @@ bool InputSystem::begin() {
   std::istringstream iss(content);
   const auto cfg = parseConfig(iss);
   initButtonsFromConfig(cfg);
+  initLedsFromConfig(cfg);
   return true;
 }
 
-void InputSystem::update() 
+void InputSystem::update()
 {
   buttons_update();
+  update_led();
 }
 
 void InputSystem::buttons_update() 
 {
-  for (auto& b : buttons) 
+  for (auto& b : buttons)
   {
     b.update();
+  }
+}
+
+void InputSystem::update_led()
+{
+  for (auto& l : leds)
+  {
+    l.update();
   }
 }
 
@@ -111,4 +121,12 @@ void InputSystem::initButtonsFromConfig(const ConfigData& cfg) {
   };
   for (const auto& e : cfg.buttons)     add(e);
   for (const auto& e : cfg.dpadButtons) add(e);
+}
+
+void InputSystem::initLedsFromConfig(const ConfigData& cfg) {
+  leds.clear();
+  for (const auto& e : cfg.leds) {
+    leds.emplace_back(uint8_t(e.value), e.name);
+    leds.back().init();
+  }
 }

--- a/src/InputSystem.h
+++ b/src/InputSystem.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <istream>
 #include "Button.h"
+#include "Led.h"
 
 class InputSystem {
 public:
@@ -28,6 +29,7 @@ public:
     bool begin();                   // mounts LittleFS, loads & parses file
     void update();                  // high-level update
     void buttons_update();          // updates all buttons
+    void update_led();              // updates all leds
     static void printConfig(const ConfigData& cfg);
 
     const std::vector<Button>& getButtons() const { return buttons; }
@@ -35,9 +37,11 @@ public:
 private:
     ConfigData parseConfig(std::istream& in);
     void initButtonsFromConfig(const ConfigData& cfg);
+    void initLedsFromConfig(const ConfigData& cfg);
 
     String fsPath;                  // "/config.txt"
     std::vector<Button> buttons;    // Buttons + DpadButtons
+    std::vector<Led> leds;          // LED outputs
 };
 
 #endif // INPUTSYSTEM_H


### PR DESCRIPTION
## Summary
- manage LEDs from config by initializing a vector of `Led` objects
- update LEDs via new `update_led` method during system update
- declare a `test` LED on pin 7 in configuration file

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68a59e107b188323adac00914fbcb4ea