### PR TITLE
Add PacketReceiver singleton for serial packet handling

### DIFF
--- a/src/PacketReceiver.cpp
+++ b/src/PacketReceiver.cpp
@@ -1,0 +1,25 @@
+#include "PacketReceiver.h"
+
+PacketReceiver& PacketReceiver::instance() {
+    static PacketReceiver inst;
+    return inst;
+}
+
+bool PacketReceiver::readPacket(Packet& outPacket) {
+    while (Serial.available()) {
+        char c = static_cast<char>(Serial.read());
+        if (c == '\n') {
+            auto sep = buffer.find(char(0x1F));
+            if (sep != std::string::npos && sep + 1 < buffer.size()) {
+                outPacket.name = buffer.substr(0, sep);
+                outPacket.value = buffer[sep + 1];
+                buffer.clear();
+                return true;
+            }
+            buffer.clear();
+        } else if (c != '\r') {
+            buffer.push_back(c);
+        }
+    }
+    return false;
+}

--- a/src/PacketReceiver.h
+++ b/src/PacketReceiver.h
@@ -1,0 +1,28 @@
+#ifndef PACKETRECEIVER_H
+#define PACKETRECEIVER_H
+
+#include <Arduino.h>
+#include <string>
+
+class PacketReceiver {
+public:
+    struct Packet {
+        std::string name;
+        char value;
+    };
+
+    static PacketReceiver& instance();
+
+    // Read the next packet from Serial into outPacket.
+    // Returns true if a complete packet was read.
+    bool readPacket(Packet& outPacket);
+
+private:
+    PacketReceiver() = default;
+    PacketReceiver(const PacketReceiver&) = delete;
+    PacketReceiver& operator=(const PacketReceiver&) = delete;
+
+    std::string buffer; // accumulates incoming data until a packet is complete
+};
+
+#endif // PACKETRECEIVER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include "InputSystem.h"
 // #include "Gearbox.h"  // <- if/when you want to re-enable the gearbox
+#include "PacketReceiver.h"
 
 // If you use the gearbox, restore the pins and object below.
 // constexpr uint8_t pPin=45, pled=44, rPin=47, rled=46, nPin=49, nled=48, dPin=51, dled=50, mPin=53, mled=52;
@@ -20,6 +21,14 @@ void setup() {
 
 void loop() {
   inputs.update();   // poll/debounce/send packets for all configured buttons
+  // Read any incoming packets and echo them for now
+  PacketReceiver::Packet pkt;
+  while (PacketReceiver::instance().readPacket(pkt)) {
+    Serial.print("Received: ");
+    Serial.print(pkt.name.c_str());
+    Serial.print(" ");
+    Serial.println(pkt.value);
+  }
   // gearbox.update(); // if used
   delay(10);
 }


### PR DESCRIPTION
## Summary
- add a `PacketReceiver` singleton to parse newline/US-delimited packets from Serial
- hook receiver into `loop()` so incoming packets are echoed to the console

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Cannot connect to proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a857cf77288323bcffcf491bd19cad