### PR TITLE
Restore button and LED polling in InputSystem loop

### DIFF
--- a/src/InputSystem.cpp
+++ b/src/InputSystem.cpp
@@ -43,8 +43,9 @@ bool InputSystem::begin() {
 
 void InputSystem::update()
 {
-  //buttons_update();
-  //update_led();
+  // Poll buttons and update any LEDs each cycle
+  buttons_update();
+  update_led();
   gearbox.update();
 }
 


### PR DESCRIPTION
## Summary
- Ensure InputSystem polls buttons and LEDs every update
- Re-enable packet transmission by calling Button::update

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3097d1ac8323840a997ac6992258