### PR TITLE
Add six-state potentiometer support

### DIFF
--- a/src/InputSystem.cpp
+++ b/src/InputSystem.cpp
@@ -36,6 +36,7 @@ bool InputSystem::begin() {
   std::istringstream iss(content);
   const auto cfg = parseConfig(iss);
   initButtonsFromConfig(cfg);
+  initPotentiometersFromConfig(cfg);
   initLedsFromConfig(cfg);
   gearbox.init(buttons, leds);
   return true;
@@ -45,6 +46,7 @@ void InputSystem::update()
 {
   // Poll buttons and update any LEDs each cycle
   buttons_update();
+  potentiometers_update();
   update_led();
   gearbox.update();
 }
@@ -54,6 +56,14 @@ void InputSystem::buttons_update()
   for (auto& b : buttons)
   {
     b.update();
+  }
+}
+
+void InputSystem::potentiometers_update()
+{
+  for (auto& p : potentiometers)
+  {
+    p.update();
   }
 }
 
@@ -148,5 +158,13 @@ void InputSystem::initLedsFromConfig(const ConfigData& cfg) {
   for (const auto& e : cfg.leds) {
     leds.emplace_back(uint8_t(e.value), e.name);
     leds.back().init();
+  }
+}
+
+void InputSystem::initPotentiometersFromConfig(const ConfigData& cfg) {
+  potentiometers.clear();
+  for (const auto& e : cfg.potentiometers) {
+    potentiometers.emplace_back(uint8_t(e.value), e.name);
+    potentiometers.back().init();
   }
 }

--- a/src/InputSystem.h
+++ b/src/InputSystem.h
@@ -9,6 +9,7 @@
 #include <istream>
 #include "Button.h"
 #include "Led.h"
+#include "Potentiometer.h"
 #include "Gearbox.h"
 
 class InputSystem {
@@ -30,19 +31,23 @@ public:
     bool begin();                   // mounts LittleFS, loads & parses file
     void update();                  // high-level update
     void buttons_update();          // updates all buttons
+    void potentiometers_update();   // updates all potentiometers
     void update_led();              // updates all leds
     static void printConfig(const ConfigData& cfg);
 
     const std::vector<Button>& getButtons() const { return buttons; }
+    const std::vector<Potentiometer>& getPotentiometers() const { return potentiometers; }
 
 private:
     ConfigData parseConfig(std::istream& in);
     void initButtonsFromConfig(const ConfigData& cfg);
+    void initPotentiometersFromConfig(const ConfigData& cfg);
     void initLedsFromConfig(const ConfigData& cfg);
 
     String fsPath;                  // "/config.txt"
     std::vector<Button> buttons;    // Buttons + DpadButtons
     std::vector<Led> leds;          // LED outputs
+    std::vector<Potentiometer> potentiometers;
     Gearbox gearbox;                //gearbox
 };
 

--- a/src/Potentiometer.cpp
+++ b/src/Potentiometer.cpp
@@ -1,0 +1,72 @@
+#include "Potentiometer.h"
+
+static constexpr int NUM_STATES = 6;
+static constexpr int ADC_MAX = 4095;
+
+Potentiometer::Potentiometer()
+{
+    ;
+}
+
+Potentiometer::Potentiometer(uint8_t pin, std::string packet_content)
+{
+    this->pot_pin = pin;
+    this->packet_content = packet_content;
+}
+
+uint8_t Potentiometer::get_pin()
+{
+    return this->pot_pin;
+}
+
+void Potentiometer::set_state(uint8_t new_state)
+{
+    this->state = new_state;
+}
+
+uint8_t Potentiometer::get_state()
+{
+    return this->state;
+}
+
+void Potentiometer::init()
+{
+#if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
+    analogReadResolution(12);
+#endif
+    pinMode(this->pot_pin, INPUT);
+    int raw = analogRead(this->pot_pin);
+    uint8_t new_state = raw / ((ADC_MAX + 1) / NUM_STATES);
+    if (new_state >= NUM_STATES) new_state = NUM_STATES - 1;
+    this->set_state(new_state);
+}
+
+void Potentiometer::update()
+{
+    int raw = analogRead(this->pot_pin);
+    uint8_t new_state = raw / ((ADC_MAX + 1) / NUM_STATES);
+    if (new_state >= NUM_STATES) new_state = NUM_STATES - 1;
+    if (new_state != this->state)
+    {
+        this->set_state(new_state);
+        this->send_packet();
+    }
+}
+
+void Potentiometer::send_packet()
+{
+    char stateCh = '0' + this->state;
+    constexpr uint8_t SEP = 0x1F;
+
+    Serial.write(reinterpret_cast<const uint8_t*>(packet_content.data()),
+                 packet_content.size());
+    Serial.write(SEP);
+    Serial.write(static_cast<uint8_t>(stateCh));
+    Serial.write('\n');
+}
+
+std::string Potentiometer::get_name()
+{
+    return this->packet_content;
+}
+

--- a/src/Potentiometer.h
+++ b/src/Potentiometer.h
@@ -1,0 +1,28 @@
+#ifndef POTENTIOMETER_H
+#define POTENTIOMETER_H
+
+#include <Arduino.h>
+#include <string>
+
+class Potentiometer {
+public:
+    Potentiometer();
+    Potentiometer(uint8_t pin, std::string packet_content);
+    void init();
+    void update();
+
+    uint8_t get_pin();
+
+    void set_state(uint8_t new_state);
+    uint8_t get_state();
+
+    void send_packet();
+    std::string get_name();
+
+private:
+    uint8_t state = 0;
+    uint8_t pot_pin;
+    std::string packet_content;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- add Potentiometer class that maps analog input into six states and transmits packets
- integrate potentiometer handling in InputSystem for initialization and periodic updates

## Testing
- `pip3 install --break-system-packages platformio` *(failed: Could not connect to proxy)*
- `g++ -c src/Potentiometer.cpp` *(failed: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b713fb034c8323ad68e817ad24a915